### PR TITLE
Fix transaction type for object modified event

### DIFF
--- a/ManholeCommands.cs
+++ b/ManholeCommands.cs
@@ -169,7 +169,9 @@ public void TestInsertOneBlock()
                 // Check if the modified attribute belongs to L TYPE PROFILE
                 if (attRef.OwnerId.IsValid)
                 {
-                    using (Transaction tr = attRef.Database.TransactionManager.StartTransaction())
+                    Document doc = Application.DocumentManager.MdiActiveDocument;
+                    using (DocumentLock docLock = doc.LockDocument())
+                    using (Transaction tr = attRef.Database.TransactionManager.StartOpenCloseTransaction())
                     {
                         var owner = tr.GetObject(attRef.OwnerId, OpenMode.ForRead) as BlockReference;
                         if (owner != null)


### PR DESCRIPTION
## Summary
- use `StartOpenCloseTransaction` when reacting to object modifications
- keep document locking around the transaction

## Testing
- `dotnet build ManholePlugin.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a6086016c8332bd9945bcab557111